### PR TITLE
Test refinement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "start": "mocha --bail --watch --require intelli-espower-loader",
-    "test": "istanbul cover _mocha --report text --report html --report lcov -- -R spec",
+    "test": "istanbul cover _mocha --report text --report html --report lcov -- -R spec --timeout 30000",
     "posttest": "npm run lint",
     "lint": "eslint lib test"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "babel-core": "^6.1.2",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.1.3",
     "babel-preset-es2015": "^6.1.2",
     "eslint": "^1.9.0",
     "eslint-config-standard": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,10 @@
     "eslint-plugin-mocha": "^1.1.0",
     "eslint-plugin-standard": "^1.3.1",
     "espower-loader": "^1.0.0",
-    "fs-extra": "^0.26.2",
     "intelli-espower-loader": "^1.0.0",
     "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
-    "power-assert": "^1.1.0",
-    "rimraf": "^2.4.3"
+    "power-assert": "^1.1.0"
   },
   "keywords": [
     "babel-plugin",

--- a/test/index.js
+++ b/test/index.js
@@ -15,9 +15,7 @@ export {foo}
 var fixturePath = 'node_modules/fixture'
 
 // Specs
-describe('babel-plugin-add-module-exports', function () {
-  this.timeout(5000) // wait for load the `babel-preset-es2015`
-
+describe('babel-plugin-add-module-exports', () => {
   beforeEach(() => {
     try {
       rimraf.sync(fixturePath)

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ function testPlugin (options, fn) {
 }
 
 describe('babel-plugin-add-module-exports', () => {
-  it('Nope.', () =>
+  it('should not export default to `module.exports` by default.', () =>
     testPlugin({
       presets: ['es2015']
     }, (module) => {
@@ -37,7 +37,7 @@ describe('babel-plugin-add-module-exports', () => {
       assert(module.foo === 'bar')
     }))
 
-  it('Add the `module.exports = Object.assign(exports.default,exports);` to EOF.', () =>
+  it('should export default to `module.exports` with this plugin', () =>
     testPlugin({
       presets: ['es2015'],
       plugins: ['../lib/index.js']
@@ -47,7 +47,7 @@ describe('babel-plugin-add-module-exports', () => {
       assert(module.foo === 'bar')
     }))
 
-  it('issue#1', () =>
+  it('should handle duplicated plugin references (#1)', () =>
     testPlugin({
       presets: ['es2015'],
       plugins: [

--- a/test/index.js
+++ b/test/index.js
@@ -29,8 +29,7 @@ describe('babel-plugin-add-module-exports', function () {
 
   it('Nope.', () => {
     var result = babel.transform(fixture, {
-      presets: ['es2015'],
-      plugins: ['transform-es2015-modules-commonjs']
+      presets: ['es2015']
     })
     fsExtra.outputFileSync(fixturePath + '/index.js', result.code)
 


### PR DESCRIPTION
- Remove `transform-es2015-modules-commonjs` plugin dependency - it is a part of es2015 perset, no need to specify it.
- Increase the timeout to 30 second - TODO investigate why test is so slow.
- Refine the test case to be a litter faster - use `vm` to simulate the require process.
- Give a more meaningful test name.