### PR TITLE
Change non-existing issue link to stackoverflow question

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Why?
 
 [babel-plugin-transform-es2015-modules-commonjs@6.1.4](https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-commonjs) doesn't support the `module.exports`.
 
-> [Kill CommonJS default export behaviour - babel/babel#2212](https://github.com/babel/babel/issues/2212)
+> [Babel 6 changes how it exports default](http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default)
 
 ```js
 // index.js


### PR DESCRIPTION
Hi, I've noticed that babel closed their issues and the issue link is no longer valid. Suggested stackoverflow question is descriptive enough to explain what happened.