### PR TITLE
fix #31 plugin should export using module.exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "cover:test": "nyc --reporter=lcov --reporter=text npm test",
     "cover:report": "npm-if TRAVIS \"codeclimate-test-reporter < coverage/lcov.info\"",
     "lint": "eslint src test",
-    "version": "node changelog.js > CHANGELOG.md && git add CHANGELOG.md",
-    "postversion": "git push --follow-tags",
+    "postversion": "node changelog.js > CHANGELOG.md && git add CHANGELOG.md && echo ':wq' | git commit --amend && git push --follow-tags",
     "build": "abby compile --log --env"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     }
   },
   "dependencies": {
-    "babel-template": "^6.5.0",
-    "lodash.get": "^4.2.1"
+    "babel-template": "^6.5.0"
   },
   "devDependencies": {
     "abigail": "^1.6.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import babelTemplate from 'babel-template'
 
-export default {
+module.exports = {
   visitor: {
     Program: {
       exit (path) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import babelTemplate from 'babel-template'
-import _get from 'lodash.get'
 
 export default {
   visitor: {
@@ -18,7 +17,7 @@ export default {
           }
           if (path.isExportNamedDeclaration()) {
             // HACK detect export-from statements for default
-            const specifiers = _get(path.get('declaration'), 'container.specifiers')
+            const specifiers = path.get('declaration').container.specifiers
             const isDefaultExportDeclaration = specifiers.length === 1 && specifiers[0].exported.name === 'default'
             if (isDefaultExportDeclaration) {
               hasExportDefault = true

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,12 @@ describe('babel-plugin-add-module-exports', () => {
       assert(module.default === 'default-entry')
     }))
 
+  it('plugin should export to module.exports(#31)', () => {
+    const plugin = require('../lib')
+    assert(typeof plugin === 'object')
+    assert(typeof plugin.visitor === 'object')
+  })
+
   it('should handle duplicated plugin references (#1)', () =>
     heplers.testPlugin(testCases[0].code, {
       presets: ['es2015'],


### PR DESCRIPTION
> [v0.1.3 is breaking changes? #31](https://github.com/59naga/babel-plugin-add-module-exports/issues/31)