### PR TITLE
Make equal() compare objects recursively, fixes #46.

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -36,6 +36,16 @@ export function equal (actual, expected) {
     assert(actual.toString() === expected)
   } else if (typeof expected === 'function') {
     assert(actual() === expected())
+  } else if (Array.isArray(expected)) {
+    assert(actual.length === expected.length)
+    for (const key in expected) {
+      equal(actual[key], expected[key])
+    }
+  } else if (typeof expected === 'object') {
+    equal(Object.keys(actual), Object.keys(expected))
+    for (const prop in expected) {
+      equal(actual[prop], expected[prop])
+    }
   } else {
     assert(inspect(actual) === inspect(expected))
   }

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,8 +1,3 @@
-// HACK: keep `anonymous` function for helpers/inspect
-let defaultEntry
-// eslint-disable-next-line no-eval
-eval("defaultEntry = function () { return 'default-entry' }")
-
 module.exports = [
   {
     name: 'export default to module.exports if only export default',
@@ -44,8 +39,8 @@ module.exports = [
     name: 'export a function as default entry',
     code: 'export default () => "default-entry"',
     expected: {
-      module: defaultEntry,
-      exports: defaultEntry
+      module: () => 'default-entry',
+      exports: () => 'default-entry'
     }
   },
   {
@@ -53,11 +48,11 @@ module.exports = [
     code: 'export default () => "default-entry"; export const other = "other-entry"',
     expected: {
       module: {
-        default: defaultEntry,
+        default: () => 'default-entry',
         other: 'other-entry'
       },
       exports: {
-        default: defaultEntry,
+        default: () => 'default-entry',
         other: 'other-entry'
       }
     }


### PR DESCRIPTION
Newer versions of Node include the name where an anonymous function originated in their output of inspect, making it unsuitable to compare functions.

This changes the `equal()` helper function to instead recursively compare objects, to still ensure proper testing while also working on newer versions of Node.

It also means we can get rid of the hack for anonymous functions at the top of `spec.js`.