### PR TITLE
New opt-in option "addDefaultProperty" to maintain compatibility with Babel@6-style exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ It also works with [transform-es2015-modules-umd](http://babeljs.io/docs/plugins
 }
 ```
 
+If you're exporting an object and wish to maintain compatibility with code using the `require('./bundle.js').default` syntax, you can optionally enable the `addDefaultProperty` option as follows:
+
+```json
+{
+  "presets": ["es2015"],
+  "plugins": [
+    ["add-module-exports", {
+      "addDefaultProperty": true
+    }]
+  ]
+}
+```
+This will cause a second line of code to be added which aliases the `default` name to the exported object like so:
+```js
+module.exports = exports['default'];
+module.exports.default = exports['default']
+```
+
 License
 ---
 [MIT](http://59naga.mit-license.org/)

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ class AssignmentReminder {
 module.exports = ({types}) => ({
   visitor: {
     CallExpression: {
-      exit (path) {
+      exit (path, state) {
         // Not `Object.defineProperty`, skip
         if (path.get('callee.name').node) {
           return
@@ -58,6 +58,15 @@ module.exports = ({types}) => ({
               types.expressionStatement(types.assignmentExpression(
                 '=',
                 types.memberExpression(types.identifier('module'), types.identifier('exports')),
+                types.memberExpression(types.identifier('exports'), types.stringLiteral('default'), true)
+              ))
+            ])
+          }
+          if (state.opts.addDefaultProperty) {
+            program.pushContainer('body', [
+              types.expressionStatement(types.assignmentExpression(
+                '=',
+                types.memberExpression(types.memberExpression(types.identifier('module'), types.identifier('exports')), types.identifier('default')),
                 types.memberExpression(types.identifier('exports'), types.stringLiteral('default'), true)
               ))
             ])

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ describe('babel-plugin-add-module-exports', () => {
         presets: ['env'],
         plugins: [
           'transform-export-extensions', // use export-from syntax
-          './src/index.js'
+          ['./src/index.js', testCase.options]
         ]
       }, (module) => {
         // assert module root (module.exports) object

--- a/test/spec.js
+++ b/test/spec.js
@@ -117,5 +117,42 @@ module.exports = [
         BAR: 2
       }
     }
+  },
+  {
+    name: 'add a default property to the exported object',
+    options: { addDefaultProperty: true },
+    code: 'export default { foo: "bar" }',
+    expected: {
+      // eslint-disable-next-line no-return-assign
+      module: { foo: 'bar', default: function () { return this.default = this } }.default(),
+      // eslint-disable-next-line no-return-assign
+      exports: { foo: 'bar', default: function () { return this.default = this } }.default()
+    }
+  },
+  {
+    name: 'add a default property to the exported function',
+    options: { addDefaultProperty: true },
+    code: 'export default () => "default-entry"',
+    expected: {
+      // eslint-disable-next-line no-return-assign
+      module: ((f) => f.default = f)(() => 'default-entry'),
+      // eslint-disable-next-line no-return-assign
+      exports: ((f) => f.default = f)(() => 'default-entry')
+    }
+  },
+  {
+    name: 'do not add default property when multiple items are exported',
+    options: { addDefaultProperty: true },
+    code: 'export default () => "default-entry"; export const other = "other-entry"',
+    expected: {
+      module: {
+        default: () => 'default-entry',
+        other: 'other-entry'
+      },
+      exports: {
+        default: () => 'default-entry',
+        other: 'other-entry'
+      }
+    }
   }
 ]

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,6 +1,7 @@
 module.exports = [
   {
     name: 'export default to module.exports if only export default',
+    options: {},
     code: 'export default "default-entry"',
     expected: {
       module: 'default-entry',
@@ -9,6 +10,7 @@ module.exports = [
   },
   {
     name: 'export other entries to module.exports if no default entry',
+    options: {},
     code: 'export const other1 = "entry1"; export const other2 = "entry2"',
     expected: {
       module: {
@@ -23,6 +25,7 @@ module.exports = [
   },
   {
     name: 'not export default to module.exports if export multiple entries',
+    options: {},
     code: 'export default "default-entry"; export const other = "other-entry"',
     expected: {
       module: {
@@ -37,6 +40,7 @@ module.exports = [
   },
   {
     name: 'export a function as default entry',
+    options: {},
     code: 'export default () => "default-entry"',
     expected: {
       module: () => 'default-entry',
@@ -45,6 +49,7 @@ module.exports = [
   },
   {
     name: 'export default function entry with other entries',
+    options: {},
     code: 'export default () => "default-entry"; export const other = "other-entry"',
     expected: {
       module: {
@@ -59,6 +64,7 @@ module.exports = [
   },
   {
     name: 'not override default object with other export entries',
+    options: {},
     code: 'export default { value: 1 }; export const value = 2',
     expected: {
       module: {
@@ -75,6 +81,7 @@ module.exports = [
     // even be compatible with wrong behavior: https://github.com/babel/babel/issues/2212#issuecomment-131110500
     // name: 'allow the wrong default export as like in Babel 5',
     name: 'follow the Babel@5 behavior (end of #4)',
+    options: {},
     code: 'export default { name: "test", version: "0.0.1" }',
     expected: {
       module: {
@@ -89,6 +96,7 @@ module.exports = [
   },
   {
     name: 'export default using transform-export-extensions (#11)',
+    options: {},
     code: "export default from './fixtures/issue011.js'",
     expected: {
       module: 'this is file',
@@ -97,6 +105,7 @@ module.exports = [
   },
   {
     name: 'export default and named declarations (#30)',
+    options: {},
     code: 'const foo = 1;const BAR = 2;export { foo as default, BAR }',
     expected: {
       module: {


### PR DESCRIPTION
As proposed in #43, an option to allow users of this plugin to automatically add a `.default` to their exported objects, maintaining backward compatibility for code using the named default export.

By making it opt-in, this functionality will not change anything for current users of this plugin, but would allow them to choose to support code using both a plain `require()` and `require().default`.

Configuration could look like this:

```json
["add-module-exports", {
   "addDefaultProperty": true
}]
```

Opting in by toggling that option to true would cause a second line of code to be added:
```diff
      module.exports = exports['default'];
>     module.exports.default = exports['default']
```

b870a0fb7c0b801b004dd182f724209cb96f9b84 contains the implementation and tests for the new option. The other commits include the changes from #49, to get the tests back up and running in the first place, and two changes to the tests to support the new test cases for the new option.