### PR TITLE
[patch] Add module.exports to files using es3 member literals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,10 @@ class ExportsFinder {
     }
 
     const objectName = path.get(`${property}.left.object.name`).node
-    const propertyName = path.get(`${property}.left.property.name`).node
+    // Check name of  MemberExpressions and values of StringLiterals
+    const propertyName =
+      path.get(`${property}.left.property.name`).node ||
+      path.get(`${property}.left.property.value`).node
     if (objectName === 'exports' || objectName === '_exports') {
       if (propertyName === 'default') {
         this.hasExportsDefault = true

--- a/test/spec.js
+++ b/test/spec.js
@@ -208,5 +208,27 @@ module.exports = [
       module: 'default-entry',
       exports: 'default-entry'
     }
+  },
+  {
+    name: 'handle a single quote string literal export',
+    code: `
+          Object.defineProperty(exports, '__esModule', {value: true});
+          exports['default'] = 'foo';
+        `,
+    expected: {
+      module: 'foo',
+      exports: 'foo'
+    }
+  },
+  {
+    name: 'handle a double quote string literal export',
+    code: `
+          Object.defineProperty(exports, '__esModule', {value: true});
+          exports["default"] = 'foo';
+        `,
+    expected: {
+      module: 'foo',
+      exports: 'foo'
+    }
   }
 ]


### PR DESCRIPTION
👋

We're using this plugin with [transform-member-literals plugin](https://babeljs.io/docs/en/next/babel-plugin-transform-member-expression-literals.html) and ran into an issue where the plugin isn't treating `exports["default"]` as a valid export. 

I updated the plugin to also check the value property on a stringLiteral and that seems to fix the issue. It would be great if we could get this patched!

cc. @ljharb