### PR TITLE
support multiple assignment of export.default in Babel 7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,7 @@ class ExportsFinder {
     if (objectName === 'exports' || objectName === '_exports') {
       if (propertyName === 'default') {
         this.hasExportsDefault = true
+        this.findExports(path.get(property), 'right')
       } else if (propertyName !== '__esModule') {
         this.hasExportsNamed = true
       }

--- a/test/spec.js
+++ b/test/spec.js
@@ -208,5 +208,19 @@ module.exports = [
       module: 'default-entry',
       exports: 'default-entry'
     }
+  },
+  {
+    name: 'export same var as default and named declarations',
+    code: 'const foo="bar";export { foo, foo as default };',
+    expected: {
+      exports: {
+        default: 'bar',
+        foo: 'bar'
+      },
+      module: {
+        default: 'bar',
+        foo: 'bar'
+      }
+    }
   }
 ]


### PR DESCRIPTION
We ran into an odd issue when migrating from Babel 6 to 7 that I tracked down to this plugin. It is specific to Babel 7 and using the same variable multiple times in a ExportNamedDeclaration. I understand that this is plugin is deprecated and don't expect new version but I thought I would leave this here for posterity.

Consider this code here:

```js
const foo = 'bar';
export { foo, foo as default };`
```

In Babel 6 it would be transpiled as:
```js
Object.defineProperty(exports, "__esModule", {
  value: true
});
var foo = 'bar';
exports.foo = foo;
exports.default = foo;
```

In Babel 7 it would be transpiled as:
```js
Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.default = exports.foo = void 0;
var foo = 'bar';
exports.default = exports.foo = foo;
```

The issue I found is that `babel-plugin-add-module-exports` will incorrectly add the `module.exports` because the `isOnlyExportsDefault()` does not correctly handle the case of `exports.default = exports.foo = foo;`. It only looks at root level expression statements and does not expect this multiple assignment.

My quick fix was to recursively call `findExports` on the right hand side of the assignment so it can analyze the other exports.

