### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ node_js:
   - 8
   - 9
   - 10
+arch:
+  - amd64
+  - ppc64le
 script:
   - yarn test
   - yarn lint


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.